### PR TITLE
Implementing benchmark regression, fixes #13

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,0 +1,49 @@
+name: Catch2 Performance Regression
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  benchmark:
+    name: Run C++ benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        # Enable performance benchmarks. Note they only make sense in release mode.
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DFLEXCLASS_BUILD_PERF_TESTS=1
+
+      - name: Build
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: cmake --build . --config $BUILD_TYPE
+
+      - name: RunPerf
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: ./tests/performance/graph | tee benchmark_result.txt
+
+      - name: Store benchmark result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          name: Catch2 Benchmark
+          tool: "catch2"
+          output-file-path: ${{runner.workspace}}/build/benchmark_result.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: "200%"
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: "@brenoguim"


### PR DESCRIPTION
- This implements a GitHub Action to track peformance benchmarks based on https://github.com/rhysd/github-action-benchmark.
- It'll warn Breno whenever there's a severe performance degradation caused by a push to master.
- I've tested this locally, the results can be seen [here](https://eullerborges.github.io/flexclass/dev/bench/).
- For this to work properly, we need to create an empty `gh-pages` branch to hold the web page that'll allow tracking performance. The final result should become available under `https://brenoguim.github.io/flexclass/dev/bench/`.  There's no way to open a pull request for a new branch in GitHub, which is unfortunate. To create the branch with an empty commit, it's possible to just:
    ```
    git checkout -b gh-pages
    git commit --allow-empty -m "Creating GitHub Pages branch"
    git push --set-upstream origin gh-pages
    ```
- It looks like there's a lot of variation on the resulting metrics. We'll need to evaluate whether tests should work over bigger samples.
- Note that there's no need to create a personal access token as proposed by the [readme on github-action-benchmark](https://github.com/rhysd/github-action-benchmark). The bug reported in the community forums has been solved recently, I'm thinking of contributing a fix to that repo (they themselves are still using private keys).