### PR TITLE
Adding preprocessed library size check (fixes #12)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,6 +11,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
+  PREPROCESSED_SIZE_LIMIT: 4500
 
 jobs:
   build:
@@ -50,3 +51,15 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: env CTEST_OUTPUT_ON_FAILURE=1 ctest -C $BUILD_TYPE
+
+    - name: Preprocess Library
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Generate the preprocessed file
+      run: make preprocess
+
+    - name: Preprocessed file size check
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Test that the pre-processed file size does not exceed the threshold.
+      run: "[[ $(cat ${{runner.workspace}}/build/tests/preprocessor/flexclass.i | wc -l)  < $PREPROCESSED_SIZE_LIMIT ]] || exit 1"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(unit)
 add_subdirectory(formatting)
 add_subdirectory(dependency)
+add_subdirectory(preprocessor)
 
 if(FLEXCLASS_BUILD_PERF_TESTS)
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/tests/preprocessor/CMakeLists.txt
+++ b/tests/preprocessor/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Creating a custom command to preprocess the library.
+# The source file includes all the code we want to preprocess (for later size measurement).
+add_custom_command(
+  OUTPUT flexclass.i
+  COMMAND "${CMAKE_CXX_COMPILER}" -E -P ${CMAKE_CURRENT_SOURCE_DIR}/include_flexclass.cpp -I${CMAKE_CURRENT_SOURCE_DIR}/../../include > flexclass.i
+  MAIN_DEPENDENCY include_flexclass.cpp
+  COMMENT "Preprocessing include_flexclass.cpp"
+  VERBATIM)
+
+add_custom_target(
+  preprocess
+  DEPENDS flexclass.i
+  COMMENT "Preprocessing flexclass library"
+  VERBATIM)
+

--- a/tests/preprocessor/include_flexclass.cpp
+++ b/tests/preprocessor/include_flexclass.cpp
@@ -1,0 +1,1 @@
+#include "flexclass/flexclass.hpp"


### PR DESCRIPTION
This includes a job in the default CMake GitHub Action to allow us to check the preprocessed size for every push. 

The `CMakeLists.txt` is a bit on the hacky side since I couldn't find a better way to instruct CMake to generate a preprocessed file. Note that with this code, this check won't ever work for the Visual Studio compiler as the syntax for preprocessing with it is a bit different.

I've tested this to work properly in my fork. Today the preprocessed library has 3558 lines (on both `Debug` and `Release`) which is why I've set the limit to 4500 lines, following a similar reasoning as that of the time of writing of #12.