### PR TITLE
Adding codecov.io support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,7 +36,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFLEXCLASS_CODE_COVERAGE=1
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -50,3 +50,8 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: env CTEST_OUTPUT_ON_FAILURE=1 ctest -C $BUILD_TYPE
+
+    - name: Upload Coverage Stats
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: "bash <(curl -s https://codecov.io/bash) || exit 1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,15 @@ project(Flexclass CXX)
 
 option(FLEXCLASS_BUILD_TESTS "Whether to build the tests" ON)
 option(FLEXCLASS_BUILD_PERF_TESTS "Whether to build the performance tests" OFF)
-option(FLEXCLASS_BUNDLE "Whether to bundle the library into a single header" ON)
+option(FLEXCLASS_CODE_COVERAGE "Enable coverage reporting" OFF)
+
+# Controls whether the library is bundled into a single header.
+# This is disabled when coverage is enabled because would break the processing of
+# coverage statistics. Coverage requires keeping sources on their original
+# locations in the repository so that we can integrate results with online # platforms.
+include(CMakeDependentOption)
+CMAKE_DEPENDENT_OPTION(FLEXCLASS_BUNDLE "Whether to bundle the library into a single header"
+                       ON "NOT FLEXCLASS_CODE_COVERAGE" OFF)
 
 set(FLEXCLASS_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include/flexclass")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(Flexclass CXX)
 
 option(FLEXCLASS_BUILD_TESTS "Whether to build the tests" ON)
 option(FLEXCLASS_BUILD_PERF_TESTS "Whether to build the performance tests" OFF)
+option(FLEXCLASS_BUNDLE "Whether to bundle the library into a single header" ON)
 
 set(FLEXCLASS_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include/flexclass")
 

--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -53,7 +53,7 @@ function(bundle _entry _output)
     set(${_output} "${output}" PARENT_SCOPE)
 endfunction()
 
-function(add_header_library _name _entry _license)
+function(add_bundled_header_library _name _entry _license)
     if(NOT IS_ABSOLUTE ${_entry})
         set(_entry "${CMAKE_CURRENT_SOURCE_DIR}/${_entry}")
     endif()
@@ -99,6 +99,15 @@ file(WRITE \"${output}\" \"\${output}\")
     add_dependencies(${_name} ${_name}.bundle)
 endfunction()
 
+function(add_header_library _name _entry _license)
+    if(FLEXCLASS_BUNDLE)
+        add_bundled_header_library(${_name} ${_entry} ${_license})
+    else()
+        add_library(${_name} INTERFACE)
+        target_include_directories(${_name} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/${_name}>)
+    endif()
+endfunction()
+
 include(CMakePackageConfigHelpers)
 
 function(deploy_header_library _lib)
@@ -106,7 +115,13 @@ function(deploy_header_library _lib)
     get_target_property(version ${_lib} INTERFACE_LIB_VERSION)
     get_target_property(dirs ${_lib} INTERFACE_INCLUDE_DIRECTORIES)
 
-    set(include_dest "include")
+    if(FLEXCLASS_BUNDLE)
+        set(include_dest "include")
+    else()
+        # We group the include files inside the flexclass directory as we're
+        # not generating a single header.
+        set(include_dest "include/flexclass")
+    endif()
     set(cmake_dest "lib/cmake/${name}")
     set(cmake_src "${CMAKE_BINARY_DIR}/${name}/${cmake_dest}")
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+  max_report_age: off
+ignore:
+  - "external"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,23 @@ add_subdirectory(unit)
 add_subdirectory(formatting)
 add_subdirectory(dependency)
 
+add_library(coverage_config INTERFACE)
+# Setup code coverage
+if(FLEXCLASS_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # Add required flags (GCC & LLVM/Clang)
+  target_compile_options(coverage_config INTERFACE
+    -O0        # no optimization
+    -g         # generate debug info
+    --coverage # sets all required flags
+  )
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+    target_link_options(coverage_config INTERFACE --coverage)
+  else()
+    target_link_libraries(coverage_config INTERFACE --coverage)
+  endif()
+endif(FLEXCLASS_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+
+
 if(FLEXCLASS_BUILD_PERF_TESTS)
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         message(FATAL_ERROR "Performance tests are meaningless in debug mode")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(test_infra
 function(make_test_lib _target_name _suffix)
     set(target_name ${_target_name}${_suffix})
     add_executable(${target_name} ${_target_name}.test.cpp)
-    target_link_libraries(${target_name} PUBLIC flexclass test_infra)
+    target_link_libraries(${target_name} PUBLIC flexclass test_infra coverage_config)
     set_target_properties(${target_name} PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
     target_include_directories(${target_name} PUBLIC ../../external/catch2/)
     add_test(


### PR DESCRIPTION
This adds support for coverage tracking under [codecov.io](https://codecov.io/).
To make this work, just create an account on codecov and merge to master. See [here](https://codecov.io/gh/eullerborges/flexclass/tree/a8c21825b7daa2023b683c0d3696f169eb5e5055/include/flexclass) for an example of a generated report.

I ran into some problems in my own fork that shouldn't happen on the clean merge here.

To make this work, we have to disable the bundling of the header libraries into a single shipped library because the code there makes CMake use the merged library for compilation when assembling tests and coverage tools will try to look into the repository for files (and the merged file won't exist on `master`). You'll see I've added a new `FLEXCLASS_BUNDLE` option that allows us to control whether we bundle the headers. I've also added code to automatically disable bundling and remove this new option when coverage is enabled (removing the option improves UX when using tools like `ccmake`).

GitHub actions are quite a pain to test, so we might run into issues here, please reach out if we do. 


Side note
------------------
We also have Coveralls as an option, but to make it work we need to add the installation of {{lcov}} on the GitHub action and I'd rather avoid that. We can still go that route if we want, we just have to replace the job I've set up here for:
``` yml
- name: lcov                                                                        
  working-directory: ${{runner.workspace}}/build                                    
  run: |                                                                            
    sudo apt-get install -y lcov                                                    
    lcov --capture --directory . --output-file coverage.info                        
    lcov --remove coverage.info '/usr/*' --output-file coverage.info                
    lcov --remove coverage.info '*/flexclass/external/*' --output-file coverage.info
    lcov --remove coverage.info '*/flexclass/tests/*' --output-file coverage.info   
                                                                                    
- name: Coveralls                                                                   
  uses: coverallsapp/github-action@master                                           
  with:                                                                             
    github-token: ${{ secrets.GITHUB_TOKEN }}                                       
    path-to-lcov: ${{runner.workspace}}/build/coverage.info                         
```
See [here](https://coveralls.io/builds/34434216) an example for the Coveralls report.