### PR TITLE
Adding HTML-generating coverage report script

### DIFF
--- a/scripts/gen_cov_report.sh
+++ b/scripts/gen_cov_report.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Script used to parse coverage information and generate a coverage report
+# using genhtml and lcov. Runs in the current directory.
+# $1: Directory where to put the HTML report
+set -e
+DESTINATION="$1"
+if [[ -z "$DESTINATION" ]]; then
+    echo -e """ Usage:
+    $(basename $0) <destination>
+"""
+    exit 1
+fi
+
+if ! which lcov >/dev/null; then
+    echo "ERROR: lcov is required to use this script. Install it with \"sudo apt install lcov\"."
+    exit 1
+fi
+
+if ! which genhtml >/dev/null; then
+    echo "ERROR: genhtml is required to use this script. Install it with \"sudo apt install lcov\"."
+    exit 1
+fi
+
+lcov --capture --directory . --output-file coverage.info
+lcov --remove coverage.info '/usr/*' --output-file coverage.info
+lcov --remove coverage.info '*/flexclass/external/*' --output-file coverage.info
+lcov --remove coverage.info '*/flexclass/tests/*' --output-file coverage.info
+
+genhtml coverage.info --output-directory "$DESTINATION"


### PR DESCRIPTION
This is a simple script that supports generating a coverage report in-place using `lcov`. This is what it looks like:
![image](https://user-images.githubusercontent.com/15127796/97094037-65a85b80-1627-11eb-90f1-12dd0692b08a.png)

I'm keeping this separate from #24 because this is completely optional. I think it's a great addition though since it allows one to check coverage statistics without pushing to GitHub. It's specially important considering our actions run only on the `master` branch.