### PR TITLE
Using mdsnippets to generate shared_array_example in README

### DIFF
--- a/.github/workflows/UpdateReadMe.yml
+++ b/.github/workflows/UpdateReadMe.yml
@@ -1,0 +1,26 @@
+name: UpdateReadMe
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run MarkdownSnippets
+      run: |
+        dotnet tool install --global MarkdownSnippets.Tool
+        mdsnippets ${GITHUB_WORKSPACE} -c InPlaceOverwrite
+      shell: bash
+    - name: Push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "Update README examples" -a  || echo "Nothing to commit"
+        remote="https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+        branch="${GITHUB_REF:11}"
+        git push "${remote}" ${branch} || echo "Nothing to push"
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The layout of the `Node` is:
                                |       |
                                |       V
 | [std::size_t]   [void*]   [Node**] | [Node*] [Node*] [Node*] ... [Node*]
-|       Id       UserData    Links   |  
+|       Id       UserData    Links   |
 |                                    |
 |                  Node              |
 ```
@@ -79,7 +79,7 @@ fc::AdjacentArray<Node*> links;
 Which would generate the following compact layout:
 ```
 |[std::size_t]   [void*]      []    | [Node*] [Node*] [Node*] ... [Node*]
-|      Id       UserData    Links   |  
+|      Id       UserData    Links   |
 |                                   |
 |                 Node              |
 ```
@@ -137,37 +137,8 @@ Cost:
 
 A shared array implementation needs a reference counter and the data (in this case an array). So it can be modeled as:
 
-```
-template<class T> class SharedArray;
-template<class T>
-class SharedArray<T[]>
-{
-    struct Impl
-    {
-        auto fc_handles() { return fc::make_tuple(&data); }
-        unsigned refCount;
-        fc::Array<T> data;
-    };
-
-  public:
-    /* Interesting public API */
-    static SharedArray make(std::size_t len) { return {fc::make<Impl>(len)(/*num references*/1u)}; }
-
-    decltype(auto) operator[](std::size_t i) { return m_data->data.begin()[i]; }
-    decltype(auto) operator[](std::size_t i) const { return m_data->data.begin()[i]; }
-
-    auto use_count() const { return m_data ? m_data->refCount : 0; }
-
-    /* See full example for special member functions */
-  private:
-    SharedArray(Impl* data) : m_data(data) {}
-    void incr() { if (m_data) m_data->refCount++; }
-    void decr() { if (m_data && m_data->refCount-- == 1) fc::destroy(m_data); }
-    Impl* m_data {nullptr};
-};
-```
-
-[See the full example here](../master/tests/unit/shared_array_example.test.cpp)
+<!-- snippet: shared_array_example -->
+<!-- endSnippet -->
 
 
 ## TODO/Known issues

--- a/tests/unit/shared_array_example.test.cpp
+++ b/tests/unit/shared_array_example.test.cpp
@@ -3,6 +3,7 @@
 
 #include <atomic>
 
+// begin-snippet: shared_array_example
 template<class T> class SharedArray;
 template<class T>
 class SharedArray<T[]>
@@ -37,6 +38,7 @@ class SharedArray<T[]>
     void decr() { if (m_data && m_data->refCount-- == 1) fc::destroy(m_data); }
     Impl* m_data {nullptr};
 };
+// end-snippet
 
 TEST_CASE( "Exercise the SharedArray", "[shared_array_example]" )
 {


### PR DESCRIPTION
Using [MarkdownSnippets](https://github.com/SimonCropp/MarkdownSnippets) to generate the example in README. The way it works is by having comments on tests (which usually are run in CI, guaranteeing they will work and not get outdated) and a placeholder comment on the README file that identifies where the snippet of code will be.
An example of it being used in another repository can be found [here](https://github.com/approvals/ApprovalTests.cpp.Qt#snippet-verify_qimage).

I'm including a workflow that runs on all push on the master branch, keeping it updated even if the test changes.

If you like this idea, I can move other examples to tests, which will allow the reuse of the code in the README file too :)